### PR TITLE
Remove replicated code

### DIFF
--- a/install/etc/cont-init.d/10-openldap
+++ b/install/etc/cont-init.d/10-openldap
@@ -25,20 +25,6 @@ function get_ldap_base_dn() {
   fi
 }
 
-
-  IFS='.' read -a domain_elems <<< "${DOMAIN}"
-  SUFFIX=""
-  ROOT=""
-
-  for elem in "${domain_elems[@]}" ; do
-      if [ "x${SUFFIX}" = x ] ; then
-          SUFFIX="dc=${elem}"
-          ROOT="${elem}"
-      else
-          BASE_DN="${SUFFIX},dc=${elem}"
-      fi
-  done
-
 function is_new_schema() {
   local COUNT=$(ldapsearch -Q -Y EXTERNAL -H ldapi:/// -b cn=schema,cn=config cn | grep -c $1)
   if [ "$COUNT" -eq 0 ]; then


### PR DESCRIPTION
This code is breaking the BASE_DN parameter. If you supply a BASE_DN with 3 elements, it ignores the middle one. Example:

BASE_DN=dc=company,dc=org,dc=br

Gets converted to

BASE_DN=dc=company,dc=br

It breaks the whole LDAP structure.