### PR TITLE
Add secrets support

### DIFF
--- a/install/etc/cont-init.d/10-openldap
+++ b/install/etc/cont-init.d/10-openldap
@@ -28,6 +28,10 @@ function get_ldap_base_dn() {
   fi
 }
 
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
 function file_env () {
   local var="$1"
   local fileVar="${var}_FILE"

--- a/install/etc/cont-init.d/10-openldap
+++ b/install/etc/cont-init.d/10-openldap
@@ -28,6 +28,23 @@ function get_ldap_base_dn() {
   fi
 }
 
+function file_env () {
+  local var="$1"
+  local fileVar="${var}_FILE"
+  local def="${2:-}"
+  local val="$def"
+  if [ "${!fileVar:-}" ]; then
+    val="$(cat "${!fileVar}")"
+  elif [ "${!var:-}" ]; then
+    val="${!var}"
+  fi
+  if [ -z ${val} ]; then
+    print_error "error: neither $var nor $fileVar are set but are required"
+    exit 1
+  fi
+  export "$var"="$val"
+  unset "$fileVar"
+}
 
   IFS='.' read -a domain_elems <<< "${DOMAIN}"
   SUFFIX=""
@@ -157,6 +174,10 @@ if [ ! -e "$FIRST_START_DONE" ]; then
 
   # Global variables
   NEW_INSTALL=false
+
+  file_env 'CONFIG_PASS'
+  file_env 'ADMIN_PASS'
+  file_env 'READONLY_USER_PASS'
 
   # database and config directory are empty
   # setup bootstrap config - Part 1

--- a/install/etc/zabbix/zabbix_agentd.conf.d/scripts/ldap-stats.sh
+++ b/install/etc/zabbix/zabbix_agentd.conf.d/scripts/ldap-stats.sh
@@ -1,5 +1,23 @@
 #!/usr/bin/with-contenv bash
 
+function file_env () {
+  local var="$1"
+  local fileVar="${var}_FILE"
+  local def="${2:-}"
+  local val="$def"
+  if [ "${!fileVar:-}" ]; then
+    val="$(cat "${!fileVar}")"
+  elif [ "${!var:-}" ]; then
+    val="${!var}"
+  fi
+  if [ -z ${val} ]; then
+    print_error "error: neither $var nor $fileVar are set but are required"
+    exit 1
+  fi
+  export "$var"="$val"
+  unset "$fileVar"
+}
+
 # if BASE_DN is empty set value from DOMAIN
   if [ -z "$BASE_DN" ]; then
     IFS='.' read -ra BASE_DN_TABLE <<< "$DOMAIN"
@@ -11,6 +29,7 @@
     BASE_DN=${BASE_DN::-1}
   fi
 
+file_env 'ADMIN_PASS'
 
 #dynamic
 LDAP_PARAM="$1"

--- a/install/etc/zabbix/zabbix_agentd.conf.d/scripts/ldap-stats.sh
+++ b/install/etc/zabbix/zabbix_agentd.conf.d/scripts/ldap-stats.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/with-contenv bash
 
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
 function file_env () {
   local var="$1"
   local fileVar="${var}_FILE"


### PR DESCRIPTION
This allows the usage of docker secrets for the following environment variables:

- `CONFIG_PASS`
- `ADMIN_PASS`
- `READONLY_USER_PASS`