### PR TITLE
Remove extra if

### DIFF
--- a/install/assets/functions/10-openldap
+++ b/install/assets/functions/10-openldap
@@ -379,9 +379,6 @@ EOF
               fi
             else
               sanity_ip=$(getent hosts $sanity_host | awk '{ print $1 }')
-              if [ -z "$sanity_ip" ]; then
-                exit 1
-              fi
               valid_ip=$(echo $sanity_ip | awk -F'.' '$1 <=255 && $2 <= 255 && $3 <= 255 && $4 <= 255')
 
               if [ -z "$valid_ip" ] || [ -z "$sanity_ip" ]; then


### PR DESCRIPTION
If `sanity_ip` is empty, there is no error message generated. No separate check is required for this in the first place since `valid_ip` will be blank when `sanity_ip` is blank.