### PR TITLE
Add option to wait for replicas to come online

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ If you already have a check_password.conf or ppm.conf in /etc/openldap/ the foll
 | `REPLICATION_CONFIG_SYNCPROV` | olcSyncRepl options used for the config database. Without rid and provider which are automatically added based on `REPLICATION_HOSTS`.                                                                                                                                              | `binddn="cn=admin,cn=config" bindmethod=simple credentials=$CONFIG_PASS searchbase="cn=config" type=refreshAndPersist retry="60 +" timeout=1 starttls=critical`                   |
 | `REPLICATION_DB_SYNCPROV`     | olcSyncRepl options used for the database. Without rid and provider which are automatically added based on `REPLICATION_HOSTS`.                                                                                                                                                     | `binddn="cn=admin,$BASE_DN" bindmethod=simple credentials=$ADMIN_PASS searchbase="$BASE_DN" type=refreshAndPersist interval=00:00:00:10 retry="60 +" timeout=1 starttls=critical` |
 | `REPLICATION_HOSTS`           | list of replication hosts seperated by a space, must contain the current container hostname set by --hostname on docker run command. If replicating all hosts must be set in the same order. Example - `ldap://ldap1.example.com ldap://ldap2.example.com ldap://ldap3.example.com` |
+| `WAIT_FOR_REPLICAS`           | should we wait for configured replicas to come online (respond to ping) before startup? | `false` | 
 
  #### Other environment variables
 

--- a/install/assets/defaults/10-openldap
+++ b/install/assets/defaults/10-openldap
@@ -60,6 +60,7 @@ TLS_KEY_PATH=${TLS_KEY_PATH:-"/certs/"}
 TLS_RESET_PERMISSIONS=${TLS_RESET_PERMISSIONS:-"TRUE"}
 TLS_VERIFY_CLIENT=${TLS_VERIFY_CLIENT:-"try"}
 ULIMIT_N=${ULIMIT_N:-"1024"}
+WAIT_FOR_REPLICAS=${WAIT_FOR_REPLICAS:-"FALSE"}
 
 first_start_done="/assets/state/slapd-first-start-done"
 was_started_with_replication="${CONFIG_PATH}slapd.d/docker-openldap-was-started-with-replication"

--- a/install/assets/functions/10-openldap
+++ b/install/assets/functions/10-openldap
@@ -371,7 +371,12 @@ EOF
         replhosts_sanity=$(grep -o -h "provider=ldap.*//.*." ${CONFIG_PATH}slapd.d/cn\=config/olcDatabase*.ldif | awk -F '[//]' '{ print $3 }' | awk -F 'binddn' '{ print $1 }' | awk '!a[$0]++' | tr '\n' ' ' | awk '!a[$0]++' | sed 's/  / /g')
         if [ ! -z "$replhosts_sanity" ]; then
           for sanity_host in $replhosts_sanity; do
-            if [[ $sanity_host =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            if var_true "$WAIT_FOR_REPLICAS"; then
+              print_debug "Waiting for $sanity_host to come online"
+              while ! ping -c1 -W1 $sanity_host; do
+                echo -n .
+              done
+            elif [[ $sanity_host =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
               sanity_ip=$sanity_host
               if [ -z "$sanity_ip" ]; then
                 print_error "It looks as if you have a malformed IP address for replication host "$sanity_host" in your schema configuration. Startup will fail!"

--- a/install/assets/functions/10-openldap
+++ b/install/assets/functions/10-openldap
@@ -373,8 +373,8 @@ EOF
           for sanity_host in $replhosts_sanity; do
             if var_true "$WAIT_FOR_REPLICAS"; then
               print_debug "Waiting for $sanity_host to come online"
-              while ! ping -c1 -W1 $sanity_host; do
-                echo -n .
+              while ! silent ping -c1 -W1 $sanity_host; do
+                silent echo -n .
               done
             elif [[ $sanity_host =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
               sanity_ip=$sanity_host


### PR DESCRIPTION
This patch adds an option to wait for replicas to come online (respond to ping) during the replication host sanity check phase.

This is relevant when a replicated cluster is brought offline completely, and then restarted. The first container to restart will fail, but subsequent containers will find its hostname routable. With this option turned on, instead of failing when the replica hostnames do not resolve, the initialization script will wait for them to become available before proceeding.

_If the cluster configuration changes while the cluster is offline (e.g. one node is renamed or removed), the state in LDAP will need to fixed by hand in any case._