### PR TITLE
Add autogroup contrib overlay

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -133,6 +133,8 @@ RUN set -x && \
     make -j$(getconf _NPROCESSORS_ONLN) DESTDIR="" prefix=/usr libexecdir=/usr/lib -C contrib/slapd-modules/passwd/sha2 install && \
     ## Build passwd Argon2
     make -j$(getconf _NPROCESSORS_ONLN) DESTDIR="" prefix=/usr libexecdir=/usr/lib -C contrib/slapd-modules/passwd/argon2 install && \
+    ## Build autogroup for dynamic groups
+    make -j$(getconf _NPROCESSORS_ONLN) DESTDIR="" prefix=/usr libexecdir=/usr/lib -C contrib/slapd-modules/autogroup install && \
     #
     ## Build ppolicy-check Module
     cd /tiredofit/openldap:`head -n 1 /tiredofit/CHANGELOG.md | awk '{print $2'}`/ && \


### PR DESCRIPTION
For openldap 2.4 the contrib/autogroup overlay is the only one which can reliably offer dynamic groups that work with memberOf. So it is basically a must-have if you want to work with dynamic groups without restrictions. In openldap 2.5 the official dynlist-layout seems (according to the beta' documentation) to gain the ability to also offer memberOf-capabilities. So with a switch to openldap 2.5 this might become obsolete.
But for the time being, this is in many cases your best bet for dynamic group setups.