### PR TITLE
Fix custom script sorting

### DIFF
--- a/install/assets/functions/10-openldap
+++ b/install/assets/functions/10-openldap
@@ -551,7 +551,7 @@ EOF
       ## Execute Custom Scripts (To be used for example for tiredofit/openldap-fusiondirectory)
       if [ -d /assets/custom-scripts/ ]; then
         print_notice "Found custom scripts to execute"
-        for f in $(find /assets/custom-scripts/ -name \*.sh -type f); do
+        for f in $(find /assets/custom-scripts/ -name \*.sh -type f | sort); do
           print_debug "Running Script ${f}"
           ${f}
         done


### PR DESCRIPTION
Apply alphabtical ordering for custom scripts

The fix in line 554 makes the order predictable (alphabetical) in which custom scripts are executed.