### PR TITLE
Add support for smbk5pwd overlay

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ RUN set -x && \
                 mosquitto-dev \
                 unixodbc-dev \
                 util-linux-dev \
+                heimdal-dev \
                 && \
     \
 ### Fetch Runtime Dependencies
@@ -135,6 +136,8 @@ RUN set -x && \
     make -j$(getconf _NPROCESSORS_ONLN) DESTDIR="" prefix=/usr libexecdir=/usr/lib -C contrib/slapd-modules/passwd/argon2 install && \
     ## Build autogroup for dynamic groups
     make -j$(getconf _NPROCESSORS_ONLN) DESTDIR="" prefix=/usr libexecdir=/usr/lib -C contrib/slapd-modules/autogroup install && \
+    ## Build smbk5pwd overlay
+    make -j$(getconf _NPROCESSORS_ONLN) DESTDIR="" prefix=/usr libexecdir=/usr/lib -C contrib/slapd-modules/smbk5pwd install && \
     #
     ## Build ppolicy-check Module
     cd /tiredofit/openldap:`head -n 1 /tiredofit/CHANGELOG.md | awk '{print $2'}`/ && \


### PR DESCRIPTION
This PR includes building the smbk5pwd overlay for syncing LDAP passwords with Samba/Kerberos.

man page: https://manpages.debian.org/unstable/slapd-smbk5pwd/slapo-smbk5pwd.5.en.html
guide: https://bangdash.space/syncing-ldap-passwords-with-samba/

The overlay is not automatically active, but has to be enabled in the openldap config (through an ldif file).