### PR TITLE
Add support for lastbind overlay

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -138,6 +138,8 @@ RUN set -x && \
     make -j$(getconf _NPROCESSORS_ONLN) DESTDIR="" prefix=/usr libexecdir=/usr/lib -C contrib/slapd-modules/autogroup install && \
     ## Build smbk5pwd overlay
     make -j$(getconf _NPROCESSORS_ONLN) DESTDIR="" prefix=/usr libexecdir=/usr/lib -C contrib/slapd-modules/smbk5pwd install && \
+    ## Build lastbind overlay
+    make -j$(getconf _NPROCESSORS_ONLN) DESTDIR="" prefix=/usr libexecdir=/usr/lib -C contrib/slapd-modules/lastbind install && \
     #
     ## Build ppolicy-check Module
     cd /tiredofit/openldap:`head -n 1 /tiredofit/CHANGELOG.md | awk '{print $2'}`/ && \


### PR DESCRIPTION
Hi,

Similar to #40 I'd like to include the lastbind overlay in the docker image.
It will not be activated automatically but can be done with the following commands on a running openldap:

```
ldapmodify -Y EXTERNAL -H ldapi:///
dn: cn=module{0},cn=config
changetype: modify
add: olcModuleload
olcModuleLoad: lastbind.la


ldapadd -Y EXTERNAL -H ldapi:///
dn: olcOverlay=lastbind,olcDatabase={1}mdb,cn=config
objectClass: olcLastBindConfig
objectClass: olcOverlayConfig
objectClass: top
olcOverlay: lastbind
olcLastBindPrecision: 60
```
