### PR TITLE
Custom Schema; incorrect find path

### DIFF
--- a/install/assets/functions/10-openldap
+++ b/install/assets/functions/10-openldap
@@ -737,7 +737,7 @@ function schema2ldif() {
     schema_dir=$(dirname ${fullpath})
     ldif_file=${schema_name}.ldif
 
-    find . -name *\}${schema_name}.ldif -exec mv '{}' ./${ldif_file} \;
+    find ${slaptest_tmp} -name *\}${schema_name}.ldif -exec mv '{}' ./${ldif_file} \;
 
     # TODO: these sed invocations could all be combined
     sed -i "/dn:/ c dn: cn=${schema_name},cn=schema,cn=config" ${ldif_file}


### PR DESCRIPTION
I believe the following location is incorrect.

https://github.com/tiredofit/docker-openldap/blob/77deb94d619aa047b7be67ffbe3bf395ee9e3307/install/assets/functions/10-openldap#L740

I attempted to add the postfix-book.schema from https://github.com/variablenix/ldap-mail-schema, into the `/assets/slapd/config/bootstrap/schema/` directory; but install would fail stating that `postfix-book.ldif` was not found.

Upon debugging; I found that the line I referenced could not find any ldif file; but it was converted in the `${slaptest_tmp}` directory. As such; I believe that the correct line would be: 

`find ${slaptest_tmp} -name *\}${schema_name}.ldif -exec mv '{}' ./${ldif_file} \;`

(Also; thank you for your amazing collection of docker containers)