### PR TITLE
Readonly User fixes (user creation and ACLs)

### DIFF
--- a/install/assets/functions/10-openldap
+++ b/install/assets/functions/10-openldap
@@ -430,16 +430,6 @@ EOF
                     fi
                 done
 
-                if var_true "${ENABLE_READONLY_USER}"; then
-                    READONLY_USER_PASS_ENCRYPTED="$(slappasswd -s "${READONLY_USER_PASS}")"
-                    for readonly_ldif in /assets/slapd/config/bootstrap/ldif/readonly-user/*.ldif; do
-                        update_template "${readonly_ldif}" \
-                            BASE_DN \
-                            READONLY_USER_USER \
-                            READONLY_USER_PASS_ENCRYPTED
-                    done
-                fi
-
                 # Adapt security and ACLs
                 print_notice "Setting Security and ACLs"
                 get_ldap_base_dn
@@ -452,6 +442,41 @@ EOF
                     print_debug "Bootstrap LDIF: Processing file ${ldif_file}"
                     ldap_add_or_modify "${ldif_file}"
                 done
+
+                # Proceed with default.sh bootstraping (creating read only user if enabled / modify ACLs accordingly)
+                if [ ! -d /assets/custom-scripts ]; then
+
+                    print_notice "No custom-scripts directory was found"
+                    if var_true "${ADD_DEFAULT_DATA}"; then
+
+                        print_notice "Adding default top level data configuration"
+                        chmod +x /assets/slapd/config/bootstrap/default/default.sh
+                        /assets/slapd/config/bootstrap/default/default.sh
+
+                        # Read only user
+                        if var_true "${ENABLE_READONLY_USER}"; then
+
+                            print_notice "Setting Security and ACLs for readonly-user"
+                            READONLY_USER_PASS_ENCRYPTED="$(slappasswd -s "${READONLY_USER_PASS}")"
+                            for readonly_ldif in /assets/slapd/config/bootstrap/ldif/readonly-user/*.ldif; do
+                                update_template "${readonly_ldif}" \
+                                    BASE_DN \
+                                    READONLY_USER_USER \
+                                    READONLY_USER_PASS_ENCRYPTED
+                            done
+
+                            #print_notice "Adding read only (DSA) user and bootstrap ldifs"
+                            #for ldif_file in $(find /assets/slapd/config/bootstrap/ldif/readonly-user -type f -name \*.ldif | sort); do
+                                #print_debug "LDIF: Processing file ${ldif_file}"
+                                ldap_add_or_modify "/assets/slapd/config/bootstrap/ldif/readonly-user/readonly-user-acl.ldif"
+                            #done
+                        fi
+                    fi
+                else
+                    # Execute Custom Scripts (To be used for example for tiredofit/openldap-fusiondirectory)
+                    print_notice "Found custom-scripts directory"
+                    custom_scripts
+                fi
 
                 # Custom LDIF injection
                 if [ -d /assets/slapd/config/bootstrap/ldif/custom ]; then
@@ -554,23 +579,6 @@ EOF
             else
                 print_debug "Disabling replication config"
                 replication_disable || true
-            fi
-
-            ## Execute Custom Scripts (To be used for example for tiredofit/openldap-fusiondirectory)
-            if [ -d /assets/custom-scripts/ ]; then
-                custom_scripts
-            else
-                if var_true "${ADD_DEFAULT_DATA}"; then
-                    print_notice "Adding default top level data configuration"
-                    chmod +x /assets/slapd/config/bootstrap/default/default.sh
-                    /assets/slapd/config/bootstrap/default/default.sh
-                    # Read only user
-                    if var_true "${ENABLE_READONLY_USER}"; then
-                        print_notice "Adding read only (DSA) user"
-                        ldap_add_or_modify "/assets/slapd/config/bootstrap/ldif/readonly-user/readonly-user.ldif"
-                        ldapmodify -H 'ldapi:///' -f /assets/slapd/config/bootstrap/ldif/readonly-user/readonly-user-acl.ldif
-                    fi
-                fi
             fi
 
             # Stop OpenLDAP

--- a/install/assets/slapd/config/bootstrap/default/default.sh
+++ b/install/assets/slapd/config/bootstrap/default/default.sh
@@ -61,7 +61,7 @@ dn: cn=${READONLY_USER_USER},${BASE_DN}
 changeType: add
 objectClass: simpleSecurityObject
 objectClass: organizationalRole
-cn: cn=${READONLY_USER_USER}
+cn: ${READONLY_USER_USER}
 description: LDAP read only user
 userPassword: ${READONLY_USER_PASS_ENCRYPTED}
 EOF

--- a/install/assets/slapd/config/bootstrap/ldif/readonly-user/readonly-user-acl.ldif
+++ b/install/assets/slapd/config/bootstrap/ldif/readonly-user/readonly-user-acl.ldif
@@ -4,5 +4,4 @@ delete: olcAccess
 -
 add: olcAccess
 olcAccess: to attrs=userPassword,shadowLastChange by self =xw by dn="cn=admin,{{BASE_DN}}" write by anonymous auth by * none
-olcAccess: to * by self write by dn="cn=admin,{{BASE_DN}}" write by * read
 olcAccess: to * by self read by dn="cn=admin,{{BASE_DN}}" write by dn="cn={{READONLY_USER_USER}},{{BASE_DN}}" read by * none

--- a/install/assets/slapd/config/bootstrap/ldif/readonly-user/readonly-user.ldif
+++ b/install/assets/slapd/config/bootstrap/ldif/readonly-user/readonly-user.ldif
@@ -3,5 +3,5 @@ changetype: add
 cn: {{READONLY_USER_USER}}
 objectClass: simpleSecurityObject
 objectClass: organizationalRole
-userPassword: {{READONLY_USER_USER}}
+userPassword: {{READONLY_USER_PASS_ENCRYPTED}}
 description: LDAP read only user (DSA)


### PR DESCRIPTION
I've been dealing with issues regarding this feature, that basically doesn't work as expected.

Changes:
- Fixed some mistakes on .ldif files
-Rewritten /install/assets/functions/10-openldap >  'configure_ldap_Server()' > 'bootstrap config part 2' process in tis way:

· Custom-script's if statement was moved up, along this section, for more clarity
· If statement was inverted and some fixes made (no more ldap errors 53 & 68)
· When true (no custom-scripts folder):
  Executes default.sh (this already includes if statement for adding readonly user)
  If ENABLE_READONLY_USER is true: Updates readonly-user templates and adds correspondent ACLs regarding olc permissions (readonly user's creationldif is not necessary because of default.sh, but left for possible usage with custom scripts...)
· When false (custom-scripts dolfer is found):
  Executes custom-scripts (totally at user's discretion of what is on their scripts...

Default and custom schemas / ldifs addition is left intact.
Working on custom repo based on branch 2.6.