### PR TITLE
Typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Clone this repository and build the image with `docker build -t (imagename) .`
 Builds of the image are available on [Docker Hub](https://hub.docker.com/r/tiredofit/openldap)
 
 ```bash
-docker pull docker.io/tiredofdit/openldap:(imagetag)
+docker pull docker.io/tiredofit/openldap:(imagetag)
 ```
 Builds of the image are also available on the [Github Container Registry](https://github.com/tiredofit/docker-openldap/pkgs/container/docker-openldap) 
  


### PR DESCRIPTION
docker.io gives unhelpful message so might save others a bit of time